### PR TITLE
Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,23 @@ The Cosmetic Disabler allows you to disable cosmetics of your choice, stopping t
 
 It will ***dynamically update*** with Team Fortress 2 and should not need to be updated after updates to detect new cosmetics.
 ## How do I use it?
+
+### Windows
 Download the latest release and run 'Cosmetic Disabler.exe' to start the program. On first time start-up you will have to provide your 'Team Fortress 2' directory.
 Once the directory is selected the program will load every cosmetic in TF2 into a list.
+
+### Linux
+1. Install Python and tkinter:
+   - **Debian/Ubuntu**: `sudo apt install python3 python3-pip python3-tk python3-venv`
+   - **Arch**: `sudo pacman -S python python-pip tk`
+   - **Fedora**: `sudo dnf install python3 python3-pip python3-tkinter python3-virtualenv`
+
+2. Make the launcher executable and run it:
+   ```bash
+   chmod +x run.sh && ./run.sh
+   ```
+
+   For subsequent runs, just use `./run.sh`
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,23 @@ Download the latest release and run 'Cosmetic Disabler.exe' to start the program
 Once the directory is selected the program will load every cosmetic in TF2 into a list.
 
 ### Linux
-1. Install Python and tkinter:
+1. Download the repository:
+   ```bash
+   git clone https://github.com/dilbertron2/Cosmetic-Disabler.git && cd Cosmetic-Disabler
+   ```
+   Or click the green **"Code"** button at the top right of the GitHub page and select "Download ZIP", then extract it.
+
+2. Install Python and tkinter:
+
    - **Debian/Ubuntu**: `sudo apt install python3 python3-pip python3-tk python3-venv`
    - **Arch**: `sudo pacman -S python python-pip tk`
    - **Fedora**: `sudo dnf install python3 python3-pip python3-tkinter python3-virtualenv`
 
-2. Make the launcher executable and run it:
+3. Make the launcher executable and run it:
    ```bash
    chmod +x run.sh && ./run.sh
    ```
-
    For subsequent runs, just use `./run.sh`
-
 
 
 You can double-click on a cosmetic to disable/re-enable it. When you are ready to create a VPK with your changes, click the 'Create VPK' button to generate the VPK file. You will be given a choice on behavior regarding cosmetic bodygroups, and then the file will be created in the same folder as the program.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+valve_parsers
+requests
+packaging
+vdf

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Check if Python 3 is installed
+if ! command -v python3 &> /dev/null; then
+    echo "Error: Python 3 is not installed."
+    echo "Please install Python 3 using your package manager:"
+    echo "  Debian/Ubuntu: sudo apt install python3 python3-pip python3-tk python3-venv"
+    echo "  Arch: sudo pacman -S python python-pip tk"
+    echo "  Fedora: sudo dnf install python3 python3-pip python3-tkinter python3-virtualenv"
+    exit 1
+fi
+
+# Check if tkinter is available
+if ! python3 -c "import tkinter" 2>/dev/null; then
+    echo "Error: tkinter is not installed."
+    echo "Please install it:"
+    echo "  Debian/Ubuntu: sudo apt install python3-tk"
+    echo "  Arch: sudo pacman -S tk"
+    echo "  Fedora: sudo dnf install python3-tkinter"
+    exit 1
+fi
+
+# Create venv if it doesn't exist
+if [ ! -d ".venv" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv .venv
+    echo "✓ Virtual environment created"
+fi
+
+# Activate venv
+source .venv/bin/activate
+
+# Install/update dependencies
+if [ -f "requirements.txt" ]; then
+    echo "Installing dependencies..."
+    pip install -q -r requirements.txt
+    echo "✓ Dependencies installed"
+fi
+
+# Run the program
+echo "Starting TF2 Cosmetic Disabler..."
+python cosmetic_disabler.py

--- a/run.sh
+++ b/run.sh
@@ -43,4 +43,4 @@ fi
 
 # Run the program
 echo "Starting TF2 Cosmetic Disabler..."
-python cosmetic_disabler.py
+python3 cosmetic_disabler.py


### PR DESCRIPTION
Normalized some paths and added some Linux default paths to the app.

Resized the window to be a little taller because the buttons were not showing by default for me.

Icon doesn't work on Linux so I just skip it.

Added a run.sh bash script for Linux users to easily run the app (essentially just the executable but for Linux).

Added steps for Linux users in the README.

@dilbertron2 you should test that these paths still work on the windows version after compilation, I can't really verify it on my end but it has no reason to not work, forward slashes are the recommended way to write paths anyways. :)